### PR TITLE
Persist user-scoped renders

### DIFF
--- a/KNOWN_GAPS.md
+++ b/KNOWN_GAPS.md
@@ -1,0 +1,4 @@
+# Known Gaps / Follow-Ups
+
+- [ ] Add integration coverage that exercises full Supabase upload + Replicate video persistence end-to-end once service mocks are available.
+- [ ] Investigate adding request correlation IDs to outbound Replicate and Supabase calls for improved observability.

--- a/PROGRESS_LOG.md
+++ b/PROGRESS_LOG.md
@@ -1,0 +1,6 @@
+# Change Log
+
+## Current Update
+- Added optional `user_context` payload handling so generated assets are scoped to authenticated users.
+- Persisted prompt-only and speech-to-video outputs to Supabase before returning URLs to clients.
+- Introduced helper utilities and unit tests covering storage prefix validation.

--- a/tests/test_storage_prefix.py
+++ b/tests/test_storage_prefix.py
@@ -1,0 +1,31 @@
+import unittest
+
+from fastapi import HTTPException
+
+from main import UserContext, resolve_user_storage_prefix, build_storage_key
+
+
+class StorageHelpersTestCase(unittest.TestCase):
+    def test_anonymous_prefix_when_context_missing(self):
+        self.assertEqual(resolve_user_storage_prefix(None), "anonymous")
+
+    def test_valid_uuid_prefix_is_normalized(self):
+        context = UserContext(id="00000000-0000-0000-0000-000000000000")
+        self.assertEqual(
+            resolve_user_storage_prefix(context),
+            "users/00000000-0000-0000-0000-000000000000",
+        )
+
+    def test_invalid_uuid_raises_http_exception(self):
+        with self.assertRaises(HTTPException) as exc:
+            resolve_user_storage_prefix(UserContext(id="not-a-uuid"))
+        self.assertEqual(exc.exception.status_code, 400)
+
+    def test_build_storage_key_scopes_to_prefix(self):
+        key = build_storage_key("users/00000000-0000-0000-0000-000000000000", "videos", "mp4")
+        self.assertTrue(key.startswith("users/00000000-0000-0000-0000-000000000000/videos/"))
+        self.assertTrue(key.endswith(".mp4"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- accept optional user_context metadata on generation requests
- persist generated audio/video under user-specific prefixes before returning URLs
- add helper coverage for storage key derivation

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68d976efb6ec8321aea722f9e1a3f781