### PR TITLE
Drop storage_key from pet video metadata

### DIFF
--- a/KNOWN_GAPS.md
+++ b/KNOWN_GAPS.md
@@ -3,3 +3,4 @@
 - [ ] Add integration coverage that exercises full Supabase upload + Replicate video persistence end-to-end once service mocks are available.
 - [ ] Investigate adding request correlation IDs to outbound Replicate and Supabase calls for improved observability.
 - [ ] Capture and surface Supabase cleanup failures so atomic rollback issues are observable in monitoring.
+- [ ] Reintroduce structured storage key persistence once the Supabase schema supports it to aid future asset lifecycle management.

--- a/PROGRESS_LOG.md
+++ b/PROGRESS_LOG.md
@@ -1,11 +1,13 @@
 # Change Log
 
 ## Current Update
+- Updated Supabase metadata persistence to drop the deprecated `storage_key` field and rely on the public `video_url`, avoiding schema mismatches.
+- Refreshed job handler and helper unit tests to reflect the simplified persistence contract.
+
+## Previous Updates
 - Added a Supabase PostgREST helper to persist generated pet video metadata alongside storage keys.
 - Updated prompt-only and TTS job handlers to invoke the helper, ensuring uploads roll back on insert failure.
 - Extended async unit coverage for the new helper and handler integration points.
-
-## Previous Updates
 - Added optional `user_context` payload handling so generated assets are scoped to authenticated users.
 - Persisted prompt-only and speech-to-video outputs to Supabase before returning URLs to clients.
 - Introduced helper utilities and unit tests covering storage prefix validation.

--- a/main.py
+++ b/main.py
@@ -363,7 +363,6 @@ async def insert_pet_video(
     *,
     user_id: str | None,
     video_url: str,
-    storage_key: str,
     image_url: str,
     script: str | None,
     prompt: str,
@@ -372,7 +371,11 @@ async def insert_pet_video(
     duration: int,
     created_at: datetime | None = None,
 ) -> None:
-    """Persist a generated pet video record via Supabase PostgREST."""
+    """Persist a generated pet video record via Supabase PostgREST.
+
+    Supabase's current schema omits the previous ``storage_key`` column, so we
+    only persist the public ``video_url`` alongside the other metadata fields.
+    """
 
     if not SUPABASE_URL or not SUPABASE_SERVICE_ROLE:
         raise HTTPException(500, "Supabase env not set")
@@ -389,7 +392,6 @@ async def insert_pet_video(
     payload = {
         "user_id": user_id,
         "video_url": video_url,
-        "storage_key": storage_key,
         "image_url": image_url,
         "script": script,
         "prompt": prompt,
@@ -619,7 +621,6 @@ async def create_job_with_prompt(req: JobPromptOnly):
         await insert_pet_video(
             user_id=user_id,
             video_url=final_url,
-            storage_key=final_key,
             image_url=req.image_url,
             script=None,
             prompt=req.prompt,
@@ -688,7 +689,6 @@ async def create_job_with_prompt_and_tts(req: JobPromptTTS):
         await insert_pet_video(
             user_id=user_id,
             video_url=final_url,
-            storage_key=final_key,
             image_url=req.image_url,
             script=req.text,
             prompt=req.prompt,

--- a/tests/test_pet_video_metadata.py
+++ b/tests/test_pet_video_metadata.py
@@ -26,7 +26,6 @@ class InsertPetVideoHelperTest(unittest.IsolatedAsyncioTestCase):
             await main.insert_pet_video(
                 user_id="user-123",
                 video_url="https://public.final/video.mp4",
-                storage_key="videos/final.mp4",
                 image_url="https://example.com/pet.jpg",
                 script="Hello!",
                 prompt="Wave hello",
@@ -52,7 +51,6 @@ class InsertPetVideoHelperTest(unittest.IsolatedAsyncioTestCase):
             {
                 "user_id": "user-123",
                 "video_url": "https://public.final/video.mp4",
-                "storage_key": "videos/final.mp4",
                 "image_url": "https://example.com/pet.jpg",
                 "script": "Hello!",
                 "prompt": "Wave hello",
@@ -95,7 +93,6 @@ class HandlerMetadataTest(unittest.IsolatedAsyncioTestCase):
             {
                 "user_id": "00000000-0000-0000-0000-000000000000",
                 "video_url": "https://public.final/video.mp4",
-                "storage_key": "videos/final.mp4",
                 "image_url": "https://example.com/pet.jpg",
                 "script": None,
                 "prompt": "Say hi",
@@ -157,7 +154,6 @@ class HandlerMetadataTest(unittest.IsolatedAsyncioTestCase):
             {
                 "user_id": "11111111-1111-1111-1111-111111111111",
                 "video_url": "https://public.final/video.mp4",
-                "storage_key": "videos/final.mp4",
                 "image_url": "https://example.com/pet.jpg",
                 "script": "Hello!",
                 "prompt": "Say hi",


### PR DESCRIPTION
## Summary
- stop sending the deprecated `storage_key` field when inserting pet video metadata so the backend matches the current Supabase schema
- update job handlers and helper tests to assert only the public `video_url` is persisted
- refresh the project change log and known gaps documentation to capture the adjustment

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9981cfdd48321980fb7cb3a72cb99