### PR TITLE
Add toggleable bearer auth guard

### DIFF
--- a/KNOWN_GAPS.md
+++ b/KNOWN_GAPS.md
@@ -4,3 +4,4 @@
 - [ ] Investigate adding request correlation IDs to outbound Replicate and Supabase calls for improved observability.
 - [ ] Capture and surface Supabase cleanup failures so atomic rollback issues are observable in monitoring.
 - [ ] Reintroduce structured storage key persistence once the Supabase schema supports it to aid future asset lifecycle management.
+- [ ] Replace the shared secret auth toggle with Supabase JWT validation once frontend session plumbing is available.

--- a/PROGRESS_LOG.md
+++ b/PROGRESS_LOG.md
@@ -1,10 +1,12 @@
 # Change Log
 
 ## Current Update
-- Updated Supabase metadata persistence to drop the deprecated `storage_key` field and rely on the public `video_url`, avoiding schema mismatches.
-- Refreshed job handler and helper unit tests to reflect the simplified persistence contract.
+- Added an opt-in bearer token auth guard that protects every endpoint when `API_AUTH_ENABLED=true`.
+- Documented the new auth environment variables and introduced unit coverage for the guard logic.
 
 ## Previous Updates
+- Updated Supabase metadata persistence to drop the deprecated `storage_key` field and rely on the public `video_url`, avoiding schema mismatches.
+- Refreshed job handler and helper unit tests to reflect the simplified persistence contract.
 - Added a Supabase PostgREST helper to persist generated pet video metadata alongside storage keys.
 - Updated prompt-only and TTS job handlers to invoke the helper, ensuring uploads roll back on insert failure.
 - Extended async unit coverage for the new helper and handler integration points.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ The service expects the following environment variables (e.g., in a `.env` file)
 - ALLOWED_ORIGIN: CORS origin, `*` by default.
 - TTS_OUTPUT_FORMAT: ElevenLabs output format (default: `mp3_44100_64`).
 - TTS_MAX_CHARS: Max TTS input length (default: `600`).
+- API_AUTH_ENABLED: When `true`, require bearer token auth for all endpoints (default: `false`).
+- API_AUTH_TOKEN: Shared secret the frontend must send as a bearer token when auth is enabled.
 
 Tip (PowerShell):
 
@@ -113,6 +115,16 @@ Base URL: http://localhost:8000
 - POST /debug/head
   - Body: { "url": "https://example.com/file" }
   - Response: { "status": 200, "content_type": "image/jpeg", "bytes": 12345 }
+
+### Authentication
+
+When `API_AUTH_ENABLED` is `true`, every endpoint requires:
+
+```
+Authorization: Bearer <API_AUTH_TOKEN>
+```
+
+Set `API_AUTH_ENABLED=false` (or unset) to temporarily allow unauthenticated requests during integration testing.
 
 Notes
 - TTS requests longer than TTS_MAX_CHARS will be rejected (400).

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,74 @@
+import unittest
+
+from fastapi import HTTPException
+from starlette.requests import Request
+
+import main
+
+
+class RequireAuthTestCase(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self._original_enabled = main.API_AUTH_ENABLED
+        self._original_token = main.API_AUTH_TOKEN
+
+    def tearDown(self) -> None:
+        main.API_AUTH_ENABLED = self._original_enabled
+        main.API_AUTH_TOKEN = self._original_token
+
+    @staticmethod
+    def _make_request(headers: dict[str, str] | None = None) -> Request:
+        scope = {
+            "type": "http",
+            "headers": [],
+        }
+        if headers:
+            scope["headers"] = [
+                (key.lower().encode("latin-1"), value.encode("latin-1"))
+                for key, value in headers.items()
+            ]
+        return Request(scope)
+
+    async def test_auth_disabled_allows_request(self):
+        main.API_AUTH_ENABLED = False
+        main.API_AUTH_TOKEN = ""
+
+        request = self._make_request()
+        await main.require_auth(request)
+
+    async def test_enabled_without_token_raises_server_error(self):
+        main.API_AUTH_ENABLED = True
+        main.API_AUTH_TOKEN = ""
+
+        request = self._make_request()
+        with self.assertRaises(HTTPException) as exc:
+            await main.require_auth(request)
+        self.assertEqual(exc.exception.status_code, 500)
+
+    async def test_missing_authorization_header_is_rejected(self):
+        main.API_AUTH_ENABLED = True
+        main.API_AUTH_TOKEN = "secret"
+
+        request = self._make_request()
+        with self.assertRaises(HTTPException) as exc:
+            await main.require_auth(request)
+        self.assertEqual(exc.exception.status_code, 401)
+
+    async def test_invalid_token_is_rejected(self):
+        main.API_AUTH_ENABLED = True
+        main.API_AUTH_TOKEN = "secret"
+
+        request = self._make_request({"Authorization": "Bearer nope"})
+        with self.assertRaises(HTTPException) as exc:
+            await main.require_auth(request)
+        self.assertEqual(exc.exception.status_code, 403)
+
+    async def test_valid_token_is_accepted(self):
+        main.API_AUTH_ENABLED = True
+        main.API_AUTH_TOKEN = "secret"
+
+        request = self._make_request({"Authorization": "Bearer secret"})
+        await main.require_auth(request)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an environment-controlled bearer token guard that protects every endpoint when enabled
- document the new auth configuration and update change tracking files
- cover the auth guard with dedicated unit tests

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68db04f9f4988321ac5f4fb1f869428b