### PR TITLE
Expose 1080p Replicate options to the frontend

### DIFF
--- a/KNOWN_GAPS.md
+++ b/KNOWN_GAPS.md
@@ -5,3 +5,4 @@
 - [ ] Capture and surface Supabase cleanup failures so atomic rollback issues are observable in monitoring.
 - [ ] Reintroduce structured storage key persistence once the Supabase schema supports it to aid future asset lifecycle management.
 - [ ] Replace the shared secret auth toggle with Supabase JWT validation once frontend session plumbing is available.
+- [ ] Confirm Kling v2.1 1080p "pro" mode output quality and aspect ratio behavior across additional prompt presets when Replicate credits are available.

--- a/PROGRESS_LOG.md
+++ b/PROGRESS_LOG.md
@@ -1,10 +1,12 @@
 # Change Log
 
 ## Current Update
-- Added an opt-in bearer token auth guard that protects every endpoint when `API_AUTH_ENABLED=true`.
-- Documented the new auth environment variables and introduced unit coverage for the guard logic.
+- Surfaced 1080p support for Replicate models in both request payloads and the `/models` metadata response so the frontend can target higher resolutions reliably.
+- Added unit coverage ensuring Kling pro mode toggles for 1080p and that supported resolutions include the new option.
 
 ## Previous Updates
+- Added an opt-in bearer token auth guard that protects every endpoint when `API_AUTH_ENABLED=true`.
+- Documented the new auth environment variables and introduced unit coverage for the guard logic.
 - Updated Supabase metadata persistence to drop the deprecated `storage_key` field and rely on the public `video_url`, avoiding schema mismatches.
 - Refreshed job handler and helper unit tests to reflect the simplified persistence contract.
 - Added a Supabase PostgREST helper to persist generated pet video metadata alongside storage keys.

--- a/main.py
+++ b/main.py
@@ -54,7 +54,7 @@ SUPPORTED_MODELS = {
             "seconds": "duration",
             "resolution": "resolution",
         },
-        "supported_resolutions": ["480p", "720p", "768p", "1024p", "1080p"],
+        "supported_resolutions": ["512p", "768p", "1080p"],
     },
     "kwaivgi/kling-v2.1": {
         "name": "Kling v2.1",
@@ -68,7 +68,7 @@ SUPPORTED_MODELS = {
             "seconds": "duration",
             "resolution": "aspect_ratio",  # Kling uses aspect ratio
         },
-        "supported_resolutions": ["768p", "1024p", "1080p"],
+        "supported_resolutions": ["720p", "1080p"],
     },
     "wan-video/wan-2.2-s2v": {
         "name": "Wan v2.2",

--- a/main.py
+++ b/main.py
@@ -54,6 +54,7 @@ SUPPORTED_MODELS = {
             "seconds": "duration",
             "resolution": "resolution",
         },
+        "supported_resolutions": ["480p", "720p", "768p", "1024p", "1080p"],
     },
     "kwaivgi/kling-v2.1": {
         "name": "Kling v2.1",
@@ -67,6 +68,7 @@ SUPPORTED_MODELS = {
             "seconds": "duration",
             "resolution": "aspect_ratio",  # Kling uses aspect ratio
         },
+        "supported_resolutions": ["768p", "1024p", "1080p"],
     },
     "wan-video/wan-2.2-s2v": {
         "name": "Wan v2.2",
@@ -94,6 +96,7 @@ SUPPORTED_MODELS = {
             "seconds": "duration",
             "resolution": "resolution",
         },
+        "supported_resolutions": ["480p", "720p", "1080p"],
     },
 }
 
@@ -273,11 +276,15 @@ def build_model_payload(
         # Handle special case for Kling which uses aspect ratio
         if model == "kwaivgi/kling-v2.1":
             # Convert resolution to aspect ratio for Kling
-            if resolution == "768p":
-                payload["input"][param_mapping["resolution"]] = "1:1"
+            payload["input"].setdefault("mode", "standard")
+            if resolution == "1080p":
+                payload["input"]["mode"] = "pro"
+                payload["input"][param_mapping["resolution"]] = "16:9"
             elif resolution == "1024p":
+                payload["input"]["mode"] = "standard"
                 payload["input"][param_mapping["resolution"]] = "16:9"
             else:
+                payload["input"]["mode"] = "standard"
                 payload["input"][param_mapping["resolution"]] = "1:1"
         elif model == "bytedance/seedance-1-lite":
             # SeeDance only accepts "480p", "720p", "1080p"
@@ -623,6 +630,8 @@ async def list_supported_models(_: None = Depends(require_auth)):
             "name": config["name"],
             "is_default": model_id == DEFAULT_MODEL,
         }
+        if "supported_resolutions" in config:
+            models[model_id]["supported_resolutions"] = config["supported_resolutions"]
     return {"supported_models": models, "default_model": DEFAULT_MODEL}
 
 

--- a/tests/test_model_resolutions.py
+++ b/tests/test_model_resolutions.py
@@ -1,0 +1,80 @@
+import unittest
+
+from fastapi.testclient import TestClient
+
+import main
+
+
+class BuildModelPayloadResolutionTestCase(unittest.TestCase):
+    def test_hailuo_passes_1080p_resolution(self):
+        payload = main.build_model_payload(
+            "minimax/hailuo-02",
+            image_url="https://example.com/image.jpg",
+            prompt="hello",
+            seconds=6,
+            resolution="1080p",
+        )
+
+        self.assertEqual(payload["input"]["resolution"], "1080p")
+
+    def test_seedance_passes_1080p_resolution(self):
+        payload = main.build_model_payload(
+            "bytedance/seedance-1-lite",
+            image_url="https://example.com/image.jpg",
+            prompt="hello",
+            seconds=6,
+            resolution="1080p",
+        )
+
+        self.assertEqual(payload["input"]["resolution"], "1080p")
+
+    def test_kling_switches_to_pro_mode_for_1080p(self):
+        payload = main.build_model_payload(
+            "kwaivgi/kling-v2.1",
+            image_url="https://example.com/image.jpg",
+            prompt="hello",
+            seconds=6,
+            resolution="1080p",
+        )
+
+        self.assertEqual(payload["input"]["mode"], "pro")
+        self.assertEqual(payload["input"]["aspect_ratio"], "16:9")
+
+    def test_kling_uses_standard_mode_for_non_1080p(self):
+        payload = main.build_model_payload(
+            "kwaivgi/kling-v2.1",
+            image_url="https://example.com/image.jpg",
+            prompt="hello",
+            seconds=6,
+            resolution="768p",
+        )
+
+        self.assertEqual(payload["input"]["mode"], "standard")
+        self.assertEqual(payload["input"]["aspect_ratio"], "1:1")
+
+
+class ModelsEndpointResolutionTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._auth_enabled = main.API_AUTH_ENABLED
+        main.API_AUTH_ENABLED = False
+        self.client = TestClient(main.app)
+
+    def tearDown(self) -> None:
+        main.API_AUTH_ENABLED = self._auth_enabled
+
+    def test_supported_models_expose_resolutions(self):
+        response = self.client.get("/models")
+        self.assertEqual(response.status_code, 200)
+
+        payload = response.json()
+        hailuo = payload["supported_models"]["minimax/hailuo-02"]
+        kling = payload["supported_models"]["kwaivgi/kling-v2.1"]
+        seedance = payload["supported_models"]["bytedance/seedance-1-lite"]
+
+        self.assertIn("1080p", hailuo["supported_resolutions"])
+        self.assertIn("1080p", kling["supported_resolutions"])
+        self.assertIn("1080p", seedance["supported_resolutions"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- expose supported resolution metadata for Replicate models so the frontend can discover 1080p-capable options
- ensure Kling v2.1 switches to pro mode when 1080p is requested and leave other models passing through the chosen resolution
- add regression tests plus log updates covering the 1080p support changes

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68db75f56d808321a196644341831627