### PR TITLE
Add model metadata to Supabase pet video records

### DIFF
--- a/KNOWN_GAPS.md
+++ b/KNOWN_GAPS.md
@@ -1,6 +1,7 @@
 # Known Gaps / Follow-Ups
 
 - [ ] Add integration coverage that exercises full Supabase upload + Replicate video persistence end-to-end once service mocks are available.
+- [ ] Confirm the Supabase `pet_videos` table includes the new `model` column and plan a backfill for historical records once deployed.
 - [ ] Investigate adding request correlation IDs to outbound Replicate and Supabase calls for improved observability.
 - [ ] Capture and surface Supabase cleanup failures so atomic rollback issues are observable in monitoring.
 - [ ] Reintroduce structured storage key persistence once the Supabase schema supports it to aid future asset lifecycle management.

--- a/PROGRESS_LOG.md
+++ b/PROGRESS_LOG.md
@@ -1,9 +1,10 @@
 # Change Log
 
 ## Current Update
-- Promoted Wan v2.2 S2V as the default image-to-video model across the API, documentation, and tests so new jobs target the higher-quality model by default.
+- Persisted the resolved Replicate model name alongside Supabase pet video metadata so downstream analytics can trace which generator produced each asset.
 
 ## Previous Updates
+- Promoted Wan v2.2 S2V as the default image-to-video model across the API, documentation, and tests so new jobs target the higher-quality model by default.
 - Switched the default image-to-video model to Wan v2.1, ensured the Replicate payload carries the `wan2.1` format flag, and verified Hailuo can still be targeted explicitly.
 - Surfaced 1080p support for Replicate models in both request payloads and the `/models` metadata response so the frontend can target higher resolutions reliably.
 - Added unit coverage ensuring Kling pro mode toggles for 1080p and that supported resolutions include the new option.

--- a/main.py
+++ b/main.py
@@ -428,12 +428,14 @@ async def insert_pet_video(
     voice_id: str | None,
     resolution: str,
     duration: int,
+    model: str,
     created_at: datetime | None = None,
 ) -> None:
     """Persist a generated pet video record via Supabase PostgREST.
 
     Supabase's current schema omits the previous ``storage_key`` column, so we
-    only persist the public ``video_url`` alongside the other metadata fields.
+    only persist the public ``video_url`` alongside the other metadata fields,
+    including the resolved Replicate ``model`` used for generation.
     """
 
     if not SUPABASE_URL or not SUPABASE_SERVICE_ROLE:
@@ -457,6 +459,7 @@ async def insert_pet_video(
         "voice_id": voice_id,
         "resolution": resolution,
         "duration": duration,
+        "model": model,
         "created_at": created_at.isoformat(),
     }
 
@@ -701,6 +704,7 @@ async def create_job_with_prompt(
             voice_id=None,
             resolution=req.resolution,
             duration=req.seconds,
+            model=model,
         )
     except Exception:
         await supabase_delete(final_key)
@@ -771,6 +775,7 @@ async def create_job_with_prompt_and_tts(
             voice_id=req.voice_id,
             resolution=req.resolution,
             duration=req.seconds,
+            model=model,
         )
     except Exception:
         if final_key:

--- a/tests/test_pet_video_metadata.py
+++ b/tests/test_pet_video_metadata.py
@@ -32,6 +32,7 @@ class InsertPetVideoHelperTest(unittest.IsolatedAsyncioTestCase):
                 voice_id="voice-id",
                 resolution="768p",
                 duration=6,
+                model="wan-video/wan-2.2-s2v",
                 created_at=created_at,
             )
 
@@ -57,6 +58,7 @@ class InsertPetVideoHelperTest(unittest.IsolatedAsyncioTestCase):
                 "voice_id": "voice-id",
                 "resolution": "768p",
                 "duration": 6,
+                "model": "wan-video/wan-2.2-s2v",
                 "created_at": created_at.isoformat(),
             },
         )
@@ -99,6 +101,7 @@ class HandlerMetadataTest(unittest.IsolatedAsyncioTestCase):
                 "voice_id": None,
                 "resolution": "768p",
                 "duration": 6,
+                "model": main.PROMPT_ONLY_FALLBACK_MODEL,
             },
         )
         self.assertEqual(
@@ -160,6 +163,7 @@ class HandlerMetadataTest(unittest.IsolatedAsyncioTestCase):
                 "voice_id": "voice-123",
                 "resolution": "768p",
                 "duration": 6,
+                "model": main.DEFAULT_MODEL,
             },
         )
         self.assertEqual(


### PR DESCRIPTION
## Summary
- persist the resolved Replicate model identifier when inserting pet video metadata
- pass the model used by prompt-only and TTS flows into Supabase inserts and update unit coverage
- log the change and follow-up work in the project progress and known gaps trackers

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68db842c9c08832190b699a30b32c371